### PR TITLE
add entrypoint with npm build step to include environment variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,5 +30,6 @@ RUN npm run build
 # expose the fact the we are running on port 3000
 EXPOSE ${NUXT_PORT}
 
-# start the app
-CMD ["npm", "start"]
+COPY entrypoint.sh .
+
+ENTRYPOINT [ "./entrypoint.sh" ]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+
+npm run build
+npm start


### PR DESCRIPTION
At the moment the docker image has to be completely rebuilt to change the environment variables RADIATOR_BASE_URL and NUXT_ROOT. With this change they are now taken over. Disadvantage of this workaround is a delayed start time of 30-60 seconds. But avoids a much longer and more complex image rebuilt.