### PR TITLE
Refactor rest api to use the global axios module instance

### DIFF
--- a/api/rest/audio.js
+++ b/api/rest/audio.js
@@ -1,21 +1,15 @@
-import axios from 'axios'
-
-export default {
+export default axios => ({
   createAudioFile: data => {
     const query = new FormData()
     query.append('audio_file[audio_id]', data.audioId)
     query.append('audio_file[file]', data.file)
     query.append('audio_file[title]', data.title)
-    return axios.post(
-      `${process.env.apiBaseUrl}/api/rest/${process.env.backendVersion}/audios/${data.audioId}/audio_files`,
-      query,
-      {
-        headers: {
-          'Content-Type': 'multipart/form-data',
-          Authorization: 'Bearer ' + data.token
-        }
+    return axios.post(`audios/${data.audioId}/audio_files`, query, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+        Authorization: 'Bearer ' + data.token
       }
-    )
+    })
   },
   createAudio: data => {
     const query = new FormData()
@@ -24,16 +18,12 @@ export default {
     if (data.image) {
       query.append('audio[image]', data.image)
     }
-    return axios.post(
-      `${process.env.apiBaseUrl}/api/rest/${process.env.backendVersion}/networks/${data.networkId}/audios`,
-      query,
-      {
-        headers: {
-          'Content-Type': 'multipart/form-data',
-          Authorization: 'Bearer ' + data.token
-        }
+    return axios.post(`networks/${data.networkId}/audios`, query, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+        Authorization: 'Bearer ' + data.token
       }
-    )
+    })
   },
   createPodcastAudio: data => {
     const query = new FormData()
@@ -42,62 +32,44 @@ export default {
     if (data.image) {
       query.append('audio[image]', data.image)
     }
-    return axios.post(
-      `${process.env.apiBaseUrl}/api/rest/${process.env.backendVersion}/episodes/${data.episodeId}/audios`,
-      query,
-      {
-        headers: {
-          'Content-Type': 'multipart/form-data',
-          Authorization: 'Bearer ' + data.token
-        }
+    return axios.post(`episodes/${data.episodeId}/audios`, query, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+        Authorization: 'Bearer ' + data.token
       }
-    )
+    })
   },
   deleteAudioFile: data => {
-    return axios.delete(
-      `${process.env.apiBaseUrl}/api/rest/${process.env.backendVersion}/audio_files/${data.id}`,
-      {
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: 'Bearer ' + data.token
-        }
+    return axios.delete(`audio_files/${data.id}`, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer ' + data.token
       }
-    )
+    })
   },
   deleteAudioPublication: data => {
-    return axios.delete(
-      `${process.env.apiBaseUrl}/api/rest/${process.env.backendVersion}/audio_publications/${data.id}`,
-      {
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: 'Bearer ' + data.token
-        }
+    return axios.delete(`audio_publications/${data.id}`, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer ' + data.token
       }
-    )
+    })
   },
   depublishAudioPublication: data => {
-    return axios.put(
-      `${process.env.apiBaseUrl}/api/rest/${process.env.backendVersion}/audio_publications/${data.id}/depublish`,
-      null,
-      {
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: 'Bearer ' + data.token
-        }
+    return axios.put(`audio_publications/${data.id}/depublish`, null, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer ' + data.token
       }
-    )
+    })
   },
   publishAudioPublication: data => {
-    return axios.put(
-      `${process.env.apiBaseUrl}/api/rest/${process.env.backendVersion}/audio_publications/${data.id}/publish`,
-      null,
-      {
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: 'Bearer ' + data.token
-        }
+    return axios.put(`audio_publications/${data.id}/publish`, null, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer ' + data.token
       }
-    )
+    })
   },
   updateAudio: data => {
     const query = new FormData()
@@ -107,16 +79,12 @@ export default {
     if (data.title) {
       query.append('audio[title]', data.title)
     }
-    return axios.patch(
-      `${process.env.apiBaseUrl}/api/rest/${process.env.backendVersion}/audios/${data.audioId}`,
-      query,
-      {
-        headers: {
-          'Content-Type': 'multipart/form-data',
-          Authorization: 'Bearer ' + data.token
-        }
+    return axios.patch(`audios/${data.audioId}`, query, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+        Authorization: 'Bearer ' + data.token
       }
-    )
+    })
   },
   updateAudioPublication: data => {
     const query = new FormData()
@@ -126,15 +94,11 @@ export default {
     if (data.publishState) {
       query.append('audio_publication[publish_state]', data.publishState)
     }
-    return axios.patch(
-      `${process.env.apiBaseUrl}/api/rest/${process.env.backendVersion}/audio_publications/${data.id}`,
-      query,
-      {
-        headers: {
-          'Content-Type': 'multipart/form-data',
-          Authorization: 'Bearer ' + data.token
-        }
+    return axios.patch(`audio_publications/${data.id}`, query, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+        Authorization: 'Bearer ' + data.token
       }
-    )
+    })
   }
-}
+})

--- a/api/rest/auth.js
+++ b/api/rest/auth.js
@@ -1,25 +1,19 @@
-import axios from 'axios'
-
-export default {
+export default axios => ({
   login: data => {
     const query = JSON.stringify({
       name: data.username,
       password: data.password
     })
 
-    return axios.post(
-      `${process.env.apiBaseUrl}/api/rest/${process.env.backendVersion}/auth`,
-      query,
-      {
-        headers: {
-          'Content-Type': 'application/json'
-        }
+    return axios.post(`auth`, query, {
+      headers: {
+        'Content-Type': 'application/json'
       }
-    )
+    })
   },
   prolongSession: data => {
     return axios.post(
-      `${process.env.apiBaseUrl}/api/rest/${process.env.backendVersion}/auth/prolong`,
+      `auth/prolong`,
       {},
       {
         headers: {
@@ -34,30 +28,22 @@ export default {
       name_or_email: data.name_or_email
     })
 
-    return axios.post(
-      `${process.env.apiBaseUrl}/api/rest/${process.env.backendVersion}/auth/resend_verification_email`,
-      query,
-      {
-        headers: {
-          'Content-Type': 'application/json'
-        }
+    return axios.post(`auth/resend_verification_email`, query, {
+      headers: {
+        'Content-Type': 'application/json'
       }
-    )
+    })
   },
   resetPassword: data => {
     const query = JSON.stringify({
       name_or_email: data.username
     })
 
-    return axios.post(
-      `${process.env.apiBaseUrl}/api/rest/${process.env.backendVersion}/auth/reset_password`,
-      query,
-      {
-        headers: {
-          'Content-Type': 'application/json'
-        }
+    return axios.post(`auth/reset_password`, query, {
+      headers: {
+        'Content-Type': 'application/json'
       }
-    )
+    })
   },
   signUp: data => {
     const query = JSON.stringify({
@@ -66,14 +52,10 @@ export default {
       password: data.password
     })
 
-    return axios.post(
-      `${process.env.apiBaseUrl}/api/rest/${process.env.backendVersion}/auth/signup`,
-      query,
-      {
-        headers: {
-          'Content-Type': 'application/json'
-        }
+    return axios.post(`auth/signup`, query, {
+      headers: {
+        'Content-Type': 'application/json'
       }
-    )
+    })
   }
-}
+})

--- a/api/rest/contributions.js
+++ b/api/rest/contributions.js
@@ -1,6 +1,4 @@
-import axios from 'axios'
-
-export default {
+export default axios => ({
   create: data => {
     const query = new FormData()
     // You can either send a podcast contribution or an audio contribution
@@ -12,42 +10,31 @@ export default {
     }
     query.append('contribution[contribution_role_id]', data.contributionRoleId)
     query.append('contribution[person_id]', data.personId)
-    return axios.post(
-      `${process.env.apiBaseUrl}/api/rest/${process.env.backendVersion}/contributions`,
-      query,
-      {
-        headers: {
-          'Content-Type': 'multipart/form-data',
-          Authorization: 'Bearer ' + data.token
-        }
+    return axios.post(`contributions`, query, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+        Authorization: 'Bearer ' + data.token
       }
-    )
+    })
   },
   deleteContribution: data => {
-    return axios.delete(
-      `${process.env.apiBaseUrl}/api/rest/${process.env.backendVersion}/contributions/${data.contributionId}`,
-      {
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: 'Bearer ' + data.token
-        }
+    return axios.delete(`contributions/${data.contributionId}`, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer ' + data.token
       }
-    )
+    })
   },
   update: data => {
     const query = new FormData()
     query.append('contribution[podcast_id]', data.podcastId)
     query.append('contribution[contribution_role_id]', data.contributionRoleId)
     query.append('contribution[person_id]', data.personId)
-    return axios.patch(
-      `${process.env.apiBaseUrl}/api/rest/${process.env.backendVersion}/contributions/${data.contributionId}`,
-      query,
-      {
-        headers: {
-          'Content-Type': 'multipart/form-data',
-          Authorization: 'Bearer ' + data.token
-        }
+    return axios.patch(`contributions/${data.contributionId}`, query, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+        Authorization: 'Bearer ' + data.token
       }
-    )
+    })
   }
-}
+})

--- a/api/rest/episodes.js
+++ b/api/rest/episodes.js
@@ -1,6 +1,4 @@
-import axios from 'axios'
-
-export default {
+export default axios => ({
   create: data => {
     const query = new FormData()
     query.append('episode[title]', data.title)
@@ -23,51 +21,36 @@ export default {
     if (data.publishState) {
       query.append('episode[publish_state]', data.publishState)
     }
-    return axios.post(
-      `${process.env.apiBaseUrl}/api/rest/${process.env.backendVersion}/episodes`,
-      query,
-      {
-        headers: {
-          'Content-Type': 'multipart/form-data',
-          Authorization: 'Bearer ' + data.token
-        }
+    return axios.post(`episodes`, query, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+        Authorization: 'Bearer ' + data.token
       }
-    )
+    })
   },
   delete: data => {
-    return axios.delete(
-      `${process.env.apiBaseUrl}/api/rest/${process.env.backendVersion}/episodes/${data.episodeId}`,
-      {
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: 'Bearer ' + data.token
-        }
+    return axios.delete(`episodes/${data.episodeId}`, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer ' + data.token
       }
-    )
+    })
   },
   depublishEpisode: data => {
-    return axios.put(
-      `${process.env.apiBaseUrl}/api/rest/${process.env.backendVersion}/episodes/${data.episodeId}/depublish`,
-      null,
-      {
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: 'Bearer ' + data.token
-        }
+    return axios.put(`episodes/${data.episodeId}/depublish`, null, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer ' + data.token
       }
-    )
+    })
   },
   publishEpisode: data => {
-    return axios.put(
-      `${process.env.apiBaseUrl}/api/rest/${process.env.backendVersion}/episodes/${data.episodeId}/publish`,
-      null,
-      {
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: 'Bearer ' + data.token
-        }
+    return axios.put(`episodes/${data.episodeId}/publish`, null, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer ' + data.token
       }
-    )
+    })
   },
   update: data => {
     const query = new FormData()
@@ -91,15 +74,11 @@ export default {
     if (data.publishState) {
       query.append('episode[publish_state]', data.publishState)
     }
-    return axios.put(
-      `${process.env.apiBaseUrl}/api/rest/${process.env.backendVersion}/episodes/${data.episodeId}`,
-      query,
-      {
-        headers: {
-          'Content-Type': 'multipart/form-data',
-          Authorization: 'Bearer ' + data.token
-        }
+    return axios.put(`episodes/${data.episodeId}`, query, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+        Authorization: 'Bearer ' + data.token
       }
-    )
+    })
   }
-}
+})

--- a/api/rest/networks-collaborators.js
+++ b/api/rest/networks-collaborators.js
@@ -1,26 +1,20 @@
-import axios from 'axios'
-
-export default {
+export default axios => ({
   create: data => {
     const query = JSON.stringify({
       username: data.username,
       // one of "own", "manage", "edit", "readonly",
       permisssion: data.permisssion
     })
-    return axios.post(
-      `${process.env.apiBaseUrl}/api/rest/${process.env.backendVersion}/networks/${data.id}/collaborators`,
-      query,
-      {
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: 'Bearer ' + data.token
-        }
+    return axios.post(`networks/${data.id}/collaborators`, query, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer ' + data.token
       }
-    )
+    })
   },
   delete: data => {
     return axios.delete(
-      `${process.env.apiBaseUrl}/api/rest/${process.env.backendVersion}/networks/${data.id}/collaborators/${data.username}`,
+      `networks/${data.id}/collaborators/${data.username}`,
       null,
       {
         headers: {
@@ -38,7 +32,7 @@ export default {
       }
     })
     return axios.put(
-      `${process.env.apiBaseUrl}/api/rest/${process.env.backendVersion}/networks/${data.id}/collaborators/${data.username}`,
+      `networks/${data.id}/collaborators/${data.username}`,
       query,
       {
         headers: {
@@ -48,4 +42,4 @@ export default {
       }
     )
   }
-}
+})

--- a/api/rest/networks.js
+++ b/api/rest/networks.js
@@ -1,6 +1,4 @@
-import axios from 'axios'
-
-export default {
+export default axios => ({
   create: data => {
     const query = new FormData()
     if (data.title) {
@@ -12,27 +10,20 @@ export default {
     if (data.slug) {
       query.append('network[slug]', data.slug)
     }
-    return axios.post(
-      `${process.env.apiBaseUrl}/api/rest/${process.env.backendVersion}/networks`,
-      query,
-      {
-        headers: {
-          'Content-Type': 'multipart/form-data',
-          Authorization: 'Bearer ' + data.token
-        }
+    return axios.post(`networks`, query, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+        Authorization: 'Bearer ' + data.token
       }
-    )
+    })
   },
   delete: data => {
-    return axios.delete(
-      `${process.env.apiBaseUrl}/api/rest/${process.env.backendVersion}/networks/${data.networkId}`,
-      {
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: 'Bearer ' + data.token
-        }
+    return axios.delete(`networks/${data.networkId}`, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer ' + data.token
       }
-    )
+    })
   },
   update: data => {
     const query = new FormData()
@@ -45,15 +36,11 @@ export default {
     if (data.slug) {
       query.append('network[slug]', data.slug)
     }
-    return axios.put(
-      `${process.env.apiBaseUrl}/api/rest/${process.env.backendVersion}/networks/${data.networkId}`,
-      query,
-      {
-        headers: {
-          'Content-Type': 'multipart/form-data',
-          Authorization: 'Bearer ' + data.token
-        }
+    return axios.put(`networks/${data.networkId}`, query, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+        Authorization: 'Bearer ' + data.token
       }
-    )
+    })
   }
-}
+})

--- a/api/rest/people.js
+++ b/api/rest/people.js
@@ -1,6 +1,4 @@
-import axios from 'axios'
-
-export default {
+export default axios => ({
   create: data => {
     const query = new FormData()
     query.append('person[network_id]', data.networkId)
@@ -22,16 +20,12 @@ export default {
     if (data.email) {
       query.append('person[email]', data.email)
     }
-    return axios.post(
-      `${process.env.apiBaseUrl}/api/rest/${process.env.backendVersion}/people`,
-      query,
-      {
-        headers: {
-          'Content-Type': 'multipart/form-data',
-          Authorization: 'Bearer ' + data.token
-        }
+    return axios.post(`people`, query, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+        Authorization: 'Bearer ' + data.token
       }
-    )
+    })
   },
   update: data => {
     const query = new FormData()
@@ -54,15 +48,11 @@ export default {
     if (data.email) {
       query.append('person[email]', data.email)
     }
-    return axios.patch(
-      `${process.env.apiBaseUrl}/api/rest/${process.env.backendVersion}/people/${data.personId}`,
-      query,
-      {
-        headers: {
-          'Content-Type': 'multipart/form-data',
-          Authorization: 'Bearer ' + data.token
-        }
+    return axios.patch(`people/${data.personId}`, query, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+        Authorization: 'Bearer ' + data.token
       }
-    )
+    })
   }
-}
+})

--- a/api/rest/podcasts-collaborators.js
+++ b/api/rest/podcasts-collaborators.js
@@ -1,6 +1,4 @@
-import axios from 'axios'
-
-export default {
+export default axios => ({
   create: data => {
     const query = JSON.stringify({
       podcast: {
@@ -9,28 +7,20 @@ export default {
         permission: data.permission
       }
     })
-    return axios.post(
-      `${process.env.apiBaseUrl}/api/rest/${process.env.backendVersion}/podcasts/${data.id}/collaborators`,
-      query,
-      {
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: 'Bearer ' + data.token
-        }
+    return axios.post(`podcasts/${data.id}/collaborators`, query, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer ' + data.token
       }
-    )
+    })
   },
   delete: data => {
-    return axios.delete(
-      `${process.env.apiBaseUrl}/api/rest/${process.env.backendVersion}/podcasts/${data.id}/collaborators`,
-      null,
-      {
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: 'Bearer ' + data.token
-        }
+    return axios.delete(`podcasts/${data.id}/collaborators`, null, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer ' + data.token
       }
-    )
+    })
   },
   update: data => {
     const query = JSON.stringify({
@@ -40,7 +30,7 @@ export default {
       }
     })
     return axios.put(
-      `${process.env.apiBaseUrl}/api/rest/${process.env.backendVersion}/podcasts/${data.id}/collaborators/${data.username}`,
+      `podcasts/${data.id}/collaborators/${data.username}`,
       query,
       {
         headers: {
@@ -50,4 +40,4 @@ export default {
       }
     )
   }
-}
+})

--- a/api/rest/podcasts.js
+++ b/api/rest/podcasts.js
@@ -1,6 +1,4 @@
-import axios from 'axios'
-
-export default {
+export default axios => ({
   create: data => {
     const query = new FormData()
     query.append('podcast[network_id]', data.networkId)
@@ -29,62 +27,44 @@ export default {
     if (data.owner_email) {
       query.append('podcast[owner_email]', data.ownerEmail)
     }
-    return axios.post(
-      `${process.env.apiBaseUrl}/api/rest/${process.env.backendVersion}/podcasts`,
-      query,
-      {
-        headers: {
-          'Content-Type': 'multipart/form-data',
-          Authorization: 'Bearer ' + data.token
-        }
+    return axios.post(`podcasts`, query, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+        Authorization: 'Bearer ' + data.token
       }
-    )
+    })
   },
   delete: data => {
-    return axios.delete(
-      `${process.env.apiBaseUrl}/api/rest/${process.env.backendVersion}/podcasts/${data.podcastId}`,
-      {
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: 'Bearer ' + data.token
-        }
+    return axios.delete(`podcasts/${data.podcastId}`, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer ' + data.token
       }
-    )
+    })
   },
   depublishPodcast: data => {
-    return axios.put(
-      `${process.env.apiBaseUrl}/api/rest/${process.env.backendVersion}/podcasts/${data.podcastId}/depublish`,
-      null,
-      {
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: 'Bearer ' + data.token
-        }
+    return axios.put(`podcasts/${data.podcastId}/depublish`, null, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer ' + data.token
       }
-    )
+    })
   },
   publishPodcast: data => {
-    return axios.put(
-      `${process.env.apiBaseUrl}/api/rest/${process.env.backendVersion}/podcasts/${data.podcastId}/publish`,
-      null,
-      {
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: 'Bearer ' + data.token
-        }
+    return axios.put(`podcasts/${data.podcastId}/publish`, null, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer ' + data.token
       }
-    )
+    })
   },
   read: data => {
-    return axios.get(
-      `${process.env.apiBaseUrl}/api/rest/${process.env.backendVersion}/podcasts/${data.podcastId}`,
-      {
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: 'Bearer ' + data.token
-        }
+    return axios.get(`podcasts/${data.podcastId}`, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer ' + data.token
       }
-    )
+    })
   },
   update: data => {
     const query = new FormData()
@@ -116,15 +96,11 @@ export default {
     if (data.ownerEmail) {
       query.append('podcast[owner_email]', data.ownerEmail)
     }
-    return axios.put(
-      `${process.env.apiBaseUrl}/api/rest/${process.env.backendVersion}/podcasts/${data.podcastId}`,
-      query,
-      {
-        headers: {
-          'Content-Type': 'multipart/form-data',
-          Authorization: 'Bearer ' + data.token
-        }
+    return axios.put(`podcasts/${data.podcastId}`, query, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+        Authorization: 'Bearer ' + data.token
       }
-    )
+    })
   }
-}
+})

--- a/api/rest/tasks.js
+++ b/api/rest/tasks.js
@@ -1,6 +1,4 @@
-import axios from 'axios'
-
-export default {
+export default axios => ({
   create: data => {
     const importPodcastFeed = {
       network_id: data.network_id,
@@ -13,37 +11,27 @@ export default {
     }
 
     const query = JSON.stringify({ import_podcast_feed: importPodcastFeed })
-    return axios.post(
-      `${process.env.apiBaseUrl}/api/rest/${process.env.backendVersion}/tasks`,
-      query,
-      {
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: 'Bearer ' + data.token
-        }
+    return axios.post(`tasks`, query, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer ' + data.token
       }
-    )
+    })
   },
   read: data => {
-    return axios.get(
-      `${process.env.apiBaseUrl}/api/rest/${process.env.backendVersion}/tasks/${data.taskId}`,
-      {
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: 'Bearer ' + data.token
-        }
+    return axios.get(`tasks/${data.taskId}`, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer ' + data.token
       }
-    )
+    })
   },
   delete: data => {
-    return axios.delete(
-      `${process.env.apiBaseUrl}/api/rest/${process.env.backendVersion}/tasks/${data.taskId}`,
-      {
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: 'Bearer ' + data.token
-        }
+    return axios.delete(`tasks/${data.taskId}`, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer ' + data.token
       }
-    )
+    })
   }
-}
+})

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,16 +1,18 @@
 import pkg from './package'
 
+const pathJoin = (...parts) => parts.map(p => p.replace(/\/*$/, '')).join('')
+
 // Do some local enving so we can reuse it in this file already
 const localenv = {
-  apiBaseUrl: process.env.RADIATOR_BASE_URL || 'http://localhost:4000'
+  apiBaseUrl: process.env.RADIATOR_BASE_URL || 'http://localhost:4000',
+  backendVersion: 'v1'
 }
 
 export default {
   mode: 'universal',
 
   env: {
-    apiBaseUrl: localenv.apiBaseUrl,
-    backendVersion: 'v1'
+    ...localenv
   },
 
   // potentially run in a subfolder (e.g. /manage/ in the default radiator installation)
@@ -40,7 +42,7 @@ export default {
   /*
    ** Plugins to load before mounting the App
    */
-  plugins: [],
+  plugins: ['~/plugins/axios-inject.js'],
 
   /*
    ** Nuxt.js modules
@@ -61,6 +63,14 @@ export default {
    */
   axios: {
     // See https://github.com/nuxt-community/axios-module#options
+    baseUrl: pathJoin(
+      localenv.apiBaseUrl,
+      `/api/rest/${localenv.backendVersion}`
+    ),
+    browserBaseURL: pathJoin(
+      localenv.apiBaseUrl,
+      `/api/rest/${localenv.backendVersion}`
+    )
   },
 
   /**

--- a/plugins/axios-inject.js
+++ b/plugins/axios-inject.js
@@ -1,0 +1,31 @@
+import apiPodcasts from '~/api/rest/podcasts.js'
+import apiEpisodes from '~/api/rest/episodes.js'
+import apiAudio from '~/api/rest/audio.js'
+import apiAuth from '~/api/rest/auth.js'
+import apiContributions from '~/api/rest/contributions.js'
+import apiNetworksCollaborators from '~/api/rest/networks-collaborators.js'
+import apiNetworks from '~/api/rest/networks.js'
+import apiPeople from '~/api/rest/people.js'
+import apiPodcastCollaborators from '~/api/rest/podcasts-collaborators.js'
+import apiTasks from '~/api/rest/tasks.js'
+
+export default ({ $axios }, inject) => {
+  // Inject `api` key
+  // -> app.$api
+  // -> this.$api in vue components
+  // -> this.$api in store actions/mutations
+  const api = {
+    podcasts: apiPodcasts($axios),
+    episodes: apiEpisodes($axios),
+    audio: apiAudio($axios),
+    auth: apiAuth($axios),
+    contributions: apiContributions($axios),
+    networksCollaborators: apiNetworksCollaborators($axios),
+    networks: apiNetworks($axios),
+    people: apiPeople($axios),
+    podcastColaborator: apiPodcastCollaborators($axios),
+    tasks: apiTasks($axios)
+  }
+
+  inject('api', api)
+}

--- a/store/audio.js
+++ b/store/audio.js
@@ -1,4 +1,3 @@
-import restAudio from '~/api/rest/audio'
 import audio from '~/api/queries/audio.gql'
 
 // An Audio Publication (createAudioPublication)
@@ -27,7 +26,7 @@ export const actions = {
   createAudio: async function createAudio({ dispatch }, data) {
     data.token = this.$apolloHelpers.getToken()
     try {
-      const res = await restAudio.createAudio(data).then(data => {
+      const res = await this.$api.audio.createAudio(data).then(data => {
         return data && data.data
       })
       await dispatch('getAudio', {
@@ -50,7 +49,7 @@ export const actions = {
   createPodcastAudio: async function createPodcastAudio({ dispatch }, data) {
     data.token = this.$apolloHelpers.getToken()
     try {
-      const res = await restAudio.createPodcastAudio(data).then(data => {
+      const res = await this.$api.audio.createPodcastAudio(data).then(data => {
         return data && data.data
       })
       await dispatch('getAudio', {
@@ -63,7 +62,7 @@ export const actions = {
   createAudioFile: async function createAudioFile({ dispatch }, data) {
     data.token = this.$apolloHelpers.getToken()
     try {
-      await restAudio.createAudioFile(data).then(data => {
+      await this.$api.audio.createAudioFile(data).then(data => {
         return data && data.data
       })
       // use audio publication/podcast audio id for audio request
@@ -89,7 +88,7 @@ export const actions = {
   deleteAudioFile: async function deleteAudioFile({ dispatch }, data) {
     data.token = this.$apolloHelpers.getToken()
     try {
-      await restAudio.deleteAudioFile(data).then(data => {
+      await this.$api.audio.deleteAudioFile(data).then(data => {
         return data && data.data
       })
       await dispatch(
@@ -119,7 +118,7 @@ export const actions = {
   ) {
     data.token = this.$apolloHelpers.getToken()
     try {
-      await restAudio.deleteAudioPublication(data).then(data => {
+      await this.$api.audio.deleteAudioPublication(data).then(data => {
         return data && data.data
       })
       await dispatch(
@@ -139,7 +138,7 @@ export const actions = {
   ) {
     data.token = this.$apolloHelpers.getToken()
     try {
-      await restAudio.depublishAudioPublication(data).then(data => {
+      await this.$api.audio.depublishAudioPublication(data).then(data => {
         return data && data.data
       })
       await dispatch('getAudio', {
@@ -172,7 +171,7 @@ export const actions = {
   ) {
     data.token = this.$apolloHelpers.getToken()
     try {
-      await restAudio.publishAudioPublication(data).then(data => {
+      await this.$api.audio.publishAudioPublication(data).then(data => {
         return data && data.data
       })
       await dispatch('getAudio', {
@@ -190,7 +189,7 @@ export const actions = {
   updateAudio: async function updateAudio({ dispatch }, data) {
     data.token = this.$apolloHelpers.getToken()
     try {
-      await restAudio.updateAudio(data).then(data => {
+      await this.$api.audio.updateAudio(data).then(data => {
         return data && data.data
       })
       await dispatch('getAudio', {
@@ -216,7 +215,7 @@ export const actions = {
   ) {
     data.token = this.$apolloHelpers.getToken()
     try {
-      await restAudio.updateAudioPublication(data).then(data => {
+      await this.$api.audio.updateAudioPublication(data).then(data => {
         return data && data.data
       })
       return await dispatch('getAudio', {

--- a/store/auth.js
+++ b/store/auth.js
@@ -1,5 +1,4 @@
 import Vue from 'vue'
-import authRest from '~/api/rest/auth'
 
 export const state = () => ({
   isLoggedIn: null
@@ -29,7 +28,7 @@ export const actions = {
   login: async function login({ dispatch }, data) {
     data.token = this.$apolloHelpers.getToken()
     try {
-      const res = await authRest.login(data).then(data => {
+      const res = await this.$api.auth.login(data).then(data => {
         return data && data.data
       })
       await this.$apolloHelpers.onLogin(res.token, undefined, 7)
@@ -56,9 +55,11 @@ export const actions = {
   renewToken: async function renewToken({ dispatch }) {
     const token = this.$apolloHelpers.getToken()
     try {
-      const res = await authRest.prolongSession({ token: token }).then(data => {
-        return data && data.data
-      })
+      const res = await this.$api.auth
+        .prolongSession({ token: token })
+        .then(data => {
+          return data && data.data
+        })
       await this.$apolloHelpers.onLogin(res.token, undefined, 7)
       await dispatch('setSession')
     } catch (e) {
@@ -68,7 +69,7 @@ export const actions = {
   resendEmail: async function resendEmail({ dispatch }, data) {
     data.token = this.$apolloHelpers.getToken()
     try {
-      await authRest.resendVerificationEmail(data).then(data => {
+      await this.$api.auth.resendVerificationEmail(data).then(data => {
         return data && data.data
       })
     } catch (e) {
@@ -78,7 +79,7 @@ export const actions = {
   resetPassword: async function resetPassword({ dispatch }, data) {
     data.token = this.$apolloHelpers.getToken()
     try {
-      await authRest.resetPassword(data).then(data => {
+      await this.$api.auth.resetPassword(data).then(data => {
         return data && data.data
       })
     } catch (e) {
@@ -97,7 +98,7 @@ export const actions = {
   signup: async function signup({ dispatch, commit }, data) {
     data.token = this.$apolloHelpers.getToken()
     try {
-      await authRest.signUp(data).then(data => {
+      await this.$api.auth.signUp(data).then(data => {
         return data && data.data
       })
     } catch (e) {

--- a/store/contributions.js
+++ b/store/contributions.js
@@ -1,4 +1,3 @@
-import restContributions from '~/api/rest/contributions'
 import contributionRoles from '~/api/queries/contributionRoles.gql'
 
 export const state = () => ({
@@ -36,7 +35,7 @@ export const actions = {
     console.log('Create Contribution', data)
     data.token = this.$apolloHelpers.getToken()
     try {
-      await restContributions.create(data).then(data => {
+      await this.$api.contributions.create(data).then(data => {
         return data && data.data
       })
       if (data.episodeId) {
@@ -77,7 +76,7 @@ export const actions = {
     console.log('Delete Contribution', data)
     data.token = this.$apolloHelpers.getToken()
     try {
-      await restContributions.deleteContribution(data).then(data => {
+      await this.$api.contributions.deleteContribution(data).then(data => {
         return data && data.data
       })
       if (data.episodeId) {
@@ -137,7 +136,7 @@ export const actions = {
     console.log('Update Contribution', data)
     data.token = this.$apolloHelpers.getToken()
     try {
-      const res = await restContributions.update(data).then(data => {
+      const res = await this.$api.contributions.update(data).then(data => {
         return data && data.data
       })
       console.log('res', res)

--- a/store/episodes.js
+++ b/store/episodes.js
@@ -1,5 +1,4 @@
 import episode from '~/api/queries/episode.gql'
-import restEpisode from '~/api/rest/episodes'
 
 export const state = () => ({
   activeEpisode: null,
@@ -35,7 +34,9 @@ export const actions = {
   create: async function create({ dispatch, commit }, data) {
     data.token = this.$apolloHelpers.getToken()
     try {
-      const res = await restEpisode.create(data).then(data => data && data.data)
+      const res = await this.$api.episodes
+        .create(data)
+        .then(data => data && data.data)
       await commit('set_active_episode', res)
     } catch (e) {
       throw Error(e)
@@ -56,7 +57,7 @@ export const actions = {
   depublishEpisode: async function depublishEpisode({ dispatch }, data) {
     data.token = this.$apolloHelpers.getToken()
     try {
-      await restEpisode.depublishEpisode(data).then(data => {
+      await this.$api.episodes.depublishEpisode(data).then(data => {
         return data && data.data
       })
       await dispatch('getEpisode', {
@@ -89,7 +90,7 @@ export const actions = {
   publishEpisode: async function publishEpisode({ dispatch }, data) {
     data.token = this.$apolloHelpers.getToken()
     try {
-      await restEpisode.publishEpisode(data).then(data => {
+      await this.$api.episodes.publishEpisode(data).then(data => {
         return data && data.data
       })
       await dispatch('getEpisode', {
@@ -107,7 +108,7 @@ export const actions = {
   update: async function updateEpisode({ dispatch }, data) {
     data.token = this.$apolloHelpers.getToken()
     try {
-      await restEpisode.update(data).then(data => data && data.data)
+      await this.$api.episodes.update(data).then(data => data && data.data)
       await dispatch('getEpisode', {
         id: data.episodeId
       })

--- a/store/feedInfo.js
+++ b/store/feedInfo.js
@@ -1,6 +1,4 @@
 import { feedInfo, getFeeds } from '~/api/queries/feedinfo.gql'
-import restTasks from '~/api/rest/tasks'
-
 export const state = () => ({
   feedInfo: {},
   feeds: {},
@@ -71,7 +69,9 @@ export const actions = {
   createTask: async function createTask({ commit }, data) {
     data.token = this.$apolloHelpers.getToken()
     try {
-      const res = await restTasks.create(data).then(data => data && data.data)
+      const res = await this.$api.tasks
+        .create(data)
+        .then(data => data && data.data)
       await commit('set_current_task', res)
     } catch (e) {
       throw Error(e)
@@ -80,7 +80,7 @@ export const actions = {
   deleteTask: async function deleteTask({ commit }, data) {
     data.token = this.$apolloHelpers.getToken()
     try {
-      await restTasks.delete(data)
+      await this.$api.tasks.delete(data)
       await commit('reset_current_task')
     } catch (e) {
       throw Error(e)
@@ -89,7 +89,9 @@ export const actions = {
   readTask: async function readTask({ commit }, data) {
     data.token = this.$apolloHelpers.getToken()
     try {
-      const res = await restTasks.read(data).then(data => data && data.data)
+      const res = await this.$api.tasks
+        .read(data)
+        .then(data => data && data.data)
       await commit('set_current_task', res)
     } catch (e) {
       throw Error(e)

--- a/store/networks.js
+++ b/store/networks.js
@@ -1,5 +1,3 @@
-import restNetwork from '~/api/rest/networks'
-import restNetworkCollaborators from '~/api/rest/networks-collaborators'
 import network from '~/api/queries/network.gql'
 import networks from '~/api/queries/networks.gql'
 
@@ -44,7 +42,7 @@ export const actions = {
   create: async function create({ dispatch, commit }, data) {
     data.token = this.$apolloHelpers.getToken()
     try {
-      const res = await restNetwork.create(data).then(data => {
+      const res = await this.$api.network.create(data).then(data => {
         return data && data.data
       })
       await commit('set_active_network', res)
@@ -61,7 +59,7 @@ export const actions = {
   ) {
     data.token = this.$apolloHelpers.getToken()
     try {
-      await restNetworkCollaborators.create(data).then(data => {
+      await this.$api.networkCollaborator.create(data).then(data => {
         return data && data.data
       })
       await dispatch('getNetworks', {
@@ -74,7 +72,7 @@ export const actions = {
   deleteNetwork: async function deleteNetwork({ dispatch }, data) {
     data.token = this.$apolloHelpers.getToken()
     try {
-      await restNetwork.delete(data).then(data => {
+      await this.$api.network.delete(data).then(data => {
         return data && data.data
       })
       await dispatch('getNetworks', {
@@ -148,7 +146,7 @@ export const actions = {
   update: async function update({ dispatch, commit }, data) {
     data.token = this.$apolloHelpers.getToken()
     try {
-      const res = await restNetwork.update(data).then(data => {
+      const res = await this.$api.network.update(data).then(data => {
         return data && data.data
       })
       await commit('set_active_network', res)
@@ -165,7 +163,7 @@ export const actions = {
   ) {
     data.token = this.$apolloHelpers.getToken()
     try {
-      const res = await restNetwork.update(data).then(data => {
+      const res = await this.$api.network.update(data).then(data => {
         return data && data.data
       })
       await commit('set_active_network', res)

--- a/store/people.js
+++ b/store/people.js
@@ -1,10 +1,8 @@
-import restPeople from '~/api/rest/people'
-
 export const actions = {
   create: async function create({ dispatch }, data) {
     data.token = this.$apolloHelpers.getToken()
     try {
-      const res = await restPeople.create(data).then(data => {
+      const res = await this.$api.people.create(data).then(data => {
         return data && data.data
       })
       await dispatch(
@@ -23,7 +21,7 @@ export const actions = {
   update: async function update({ dispatch }, data) {
     data.token = this.$apolloHelpers.getToken()
     try {
-      const res = await restPeople.update(data).then(data => {
+      const res = await this.$api.people.update(data).then(data => {
         return data && data.data
       })
       if (data.contributionRoleId) {

--- a/store/podcasts.js
+++ b/store/podcasts.js
@@ -1,5 +1,3 @@
-import restPodcast from '~/api/rest/podcasts'
-import restPodcastCollaborators from '~/api/rest/podcasts-collaborators'
 import podcast from '~/api/queries/podcast.gql'
 
 export const state = () => ({
@@ -31,7 +29,9 @@ export const actions = {
   create: async function create({ dispatch, commit }, data) {
     data.token = this.$apolloHelpers.getToken()
     try {
-      const res = await restPodcast.create(data).then(data => data && data.data)
+      const res = await this.$api.podcasts
+        .create(data)
+        .then(data => data && data.data)
       await dispatch('getPodcast', {
         id: res.id
       })
@@ -52,7 +52,7 @@ export const actions = {
   ) {
     data.token = this.$apolloHelpers.getToken()
     try {
-      await restPodcastCollaborators.create(data).then(data => {
+      await this.$api.podcastsCollaborators.create(data).then(data => {
         return data && data.data
       })
       await dispatch(
@@ -69,7 +69,7 @@ export const actions = {
   deletePodcast: async function deletePodcast({ dispatch }, data) {
     data.token = this.$apolloHelpers.getToken()
     try {
-      await restPodcast.delete(data).then(data => {
+      await this.$api.podcasts.delete(data).then(data => {
         return data && data.data
       })
       await dispatch(
@@ -83,13 +83,13 @@ export const actions = {
       throw Error(e)
     }
   },
-  depublishPodcast: async function depublishPodcast({ dispatch }, data) {
+  depublishPodcast: async function depublishPodcast(app, data) {
     data.token = this.$apolloHelpers.getToken()
     try {
-      await restPodcast.depublishPodcast(data).then(data => {
+      await this.$api.depublishPodcast(data).then(data => {
         return data && data.data
       })
-      await dispatch('getPodcast', {
+      await app.dispatch('getPodcast', {
         id: data.podcastId
       })
     } catch (e) {
@@ -120,7 +120,7 @@ export const actions = {
   publishPodcast: async function publishPodcast({ dispatch }, data) {
     data.token = this.$apolloHelpers.getToken()
     try {
-      await restPodcast.publishPodcast(data).then(data => {
+      await this.$api.publishPodcast(data).then(data => {
         return data && data.data
       })
       await dispatch('getPodcast', {
@@ -138,7 +138,7 @@ export const actions = {
   update: async function update({ dispatch, commit }, data) {
     data.token = this.$apolloHelpers.getToken()
     try {
-      await restPodcast.update(data).then(data => {
+      await this.$api.podcasts.update(data).then(data => {
         return data && data.data
       })
       await dispatch('getPodcast', {


### PR DESCRIPTION
You can use the global axios module and its global configuration. This is possible through a nuxt plugin that injects the $axios instance into the global context and builds an api factory. 

Proposed by a nuxt core developer here https://github.com/nuxt-community/modules/issues/112#issuecomment-328268059 and here https://blog.lichter.io/posts/nuxt-api-call-organization-and-decoupling/

This changes alot of files, but maybe worth it. :)